### PR TITLE
Switching to Docker 20.10.14 & buildx v0.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM docker:20.10.6
+FROM docker:20.10.14
 
-RUN wget https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64
+RUN wget https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64
 
-RUN mkdir -p ~/.docker/cli-plugins && mv buildx-v0.5.1.linux-amd64  ~/.docker/cli-plugins/docker-buildx && chmod a+x ~/.docker/cli-plugins/docker-buildx
-
+RUN mkdir -p ~/.docker/cli-plugins && mv buildx-v0.8.2.linux-amd64  ~/.docker/cli-plugins/docker-buildx && chmod a+x ~/.docker/cli-plugins/docker-buildx


### PR DESCRIPTION
Upgrading to newer versions.

Docker 20.10.6 -> 20.10.14
build v0.5.1 -> v0.8.2